### PR TITLE
Create basic child theme for Twenty Twenty-Five

### DIFF
--- a/twentytwentyfive-child/functions.php
+++ b/twentytwentyfive-child/functions.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Twenty Twenty-Five Child Theme functions and definitions
+ *
+ * @link https://developer.wordpress.org/themes/basics/theme-functions/
+ *
+ * @package Twenty Twenty-Five Child
+ */
+
+/**
+ * Enqueue scripts and styles.
+ */
+function twentytwentyfive_child_enqueue_styles() {
+	wp_enqueue_style(
+		'twentytwentyfive-parent-style',
+		get_template_directory_uri() . '/style.css'
+	);
+	wp_enqueue_style(
+		'twentytwentyfive-child-style',
+		get_stylesheet_directory_uri() . '/style.css',
+		array( 'twentytwentyfive-parent-style' ),
+		wp_get_theme()->get( 'Version' )
+	);
+}
+add_action( 'wp_enqueue_scripts', 'twentytwentyfive_child_enqueue_styles' );

--- a/twentytwentyfive-child/style.css
+++ b/twentytwentyfive-child/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: Twenty Twenty-Five Child
+Theme URI: https://example.com/twentytwentyfive-child/
+Description: A child theme for Twenty Twenty-Five.
+Author: Your Name
+Author URI: https://example.com
+Template: twentytwentyfive
+Version: 1.0.0
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Tags: light, dark, two-columns, right-sidebar, responsive-layout, accessibility-ready
+Text Domain: twentytwentyfive-child
+*/
+
+/* Add your custom CSS below */


### PR DESCRIPTION
This commit introduces a basic child theme for the Twenty Twenty-Five theme. The child theme is named "Twenty Twenty-Five Child" and includes:
- A `style.css` file with the necessary headers to identify it as a child theme of `twentytwentyfive`.
- A `functions.php` file that correctly enqueues the parent theme's stylesheet and the child theme's own stylesheet.

This provides a starting point for you if you wish to customize the Twenty Twenty-Five theme without directly modifying the parent theme's files, ensuring that your customizations are preserved during parent theme updates.