### PR TITLE
feat: Add GitHub Actions workflow for child theme deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,1 +1,31 @@
+name: Deploy to A2 Hosting
 
+on:
+  push:
+    branches:
+      - main  # Or your default branch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Deploy to server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.A2_HOST }}
+          username: ${{ secrets.A2_USERNAME }}
+          key: ${{ secrets.A2_SSH_KEY }}
+          port: 22 # Or your SSH port if different
+          script: |
+            # Ensure the target directory exists
+            mkdir -p public_html/wp-content/themes/
+            # Deploy the child theme. -avzP are rsync options:
+            # a: archive mode (preserves permissions, ownership, timestamps, etc.)
+            # v: verbose
+            # z: compress file data during the transfer
+            # P: equivalent to --partial --progress, useful for resuming interrupted transfers
+            rsync -avzP --delete twentytwentyfive-child/ public_html/wp-content/themes/twentytwentyfive-child/
+            echo "Deployment successful!"


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow (`.github/workflows/deploy.yml`) to automate the deployment of the `twentytwentyfive-child` theme to A2 Hosting.

The workflow triggers on pushes to the main branch and uses `appleboy/ssh-action` with `rsync` to transfer the `twentytwentyfive-child/` directory to `public_html/wp-content/themes/twentytwentyfive-child/` on the server.

You need to configure the following secrets in your GitHub repository settings for the deployment to work:
- A2_HOST: The A2 Hosting server address.
- A2_USERNAME: The SSH username for A2 Hosting.
- A2_SSH_KEY: The private SSH key for authentication.