### PR TITLE
Fix: Correct header pattern slug in template part

### DIFF
--- a/parts/header.html
+++ b/parts/header.html
@@ -1,1 +1,1 @@
-<!-- wp:pattern {"slug":"twentytwentyfive-child/custom-news-header"} /-->
+<!-- wp:pattern {"slug":"twentytwentyfive-child/advanced-news-header"} /-->


### PR DESCRIPTION
The home page was not updating because `parts/header.html` referred to a non-existent pattern slug (`twentytwentyfive-child/custom-news-header`).

This commit updates the slug to `twentytwentyfive-child/advanced-news-header`, which is the correct slug for the header pattern defined in `patterns/advanced-header.php`.

This change ensures that the correct header is loaded and that updates to `home.html` and the header pattern are reflected on the site.