### PR TITLE
Fix: Resolve home page distortion by enqueueing missing header assets.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -61,6 +61,14 @@ function twentytwentyfive_child_enqueue_assets()
 		$theme_version
 	);
 
+	// Child theme header style
+	wp_enqueue_style(
+		'twentytwentyfive-child-header-style',
+		get_stylesheet_directory_uri() . '/assets/css/header.css',
+		array('twentytwentyfive-child-style'),
+		$theme_version
+	);
+
 	// Google Fonts - Optimized loading with display=swap
 	wp_enqueue_style(
 		'google-fonts-poppins',
@@ -76,6 +84,15 @@ function twentytwentyfive_child_enqueue_assets()
 		array(),
 		$theme_version,
 		true // Load in footer for better performance
+	);
+
+	// Child theme header script
+	wp_enqueue_script(
+		'twentytwentyfive-child-header-script',
+		get_stylesheet_directory_uri() . '/assets/js/header.js',
+		array(),
+		$theme_version,
+		true // Load in footer
 	);
 
 	// Localize script for AJAX if needed


### PR DESCRIPTION
The home page was displaying a distorted version of the old design because `assets/css/header.css` and `assets/js/header.js` were not being enqueued in `functions.php`. These files are necessary for the correct rendering and functionality of the advanced header and potentially other elements on the page.

This commit updates the `twentytwentyfive_child_enqueue_assets` function in `functions.php` to properly enqueue both `header.css` and `header.js`, ensuring they are loaded with the correct dependencies and versioning. This should fix the display issues and allow the new design of `home.html` to render as intended.