### PR TITLE
Fix missing include file in child theme

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -12,8 +12,8 @@ if (!defined('ABSPATH')) {
 	exit;
 }
 
-// Include navigation walkers
-require_once get_template_directory() . '/inc/navigation-walkers.php';
+// Include navigation walkers from the child theme directory
+require_once get_stylesheet_directory() . '/inc/navigation-walkers.php';
 
 // Define content width
 $content_width = 800;


### PR DESCRIPTION
## Summary
- ensure navigation walkers are loaded from the child theme directory

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c07f656788320bc3aab80ca86c0c5